### PR TITLE
Process Improvements: Add new personas, clarify handoffs, roles, and ownership (Issue #4)

### DIFF
--- a/docs/octoacme-execution-and-tracking.md
+++ b/docs/octoacme-execution-and-tracking.md
@@ -38,3 +38,5 @@ Guidance for managing day-to-day execution and tracking progress toward project 
 - [ ] CI configured for tests and lint
 - [ ] Regular demos scheduled
 - [ ] Risk register updated weekly
+- [ ] Support Lead/readiness for post-deployment confirmed
+- [ ] DevOps and QA handoff for release validated

--- a/docs/octoacme-project-initiation.md
+++ b/docs/octoacme-project-initiation.md
@@ -18,6 +18,7 @@ Whenever a new project idea or feature proposal is ready to be explored.
 - High-level timeline and key milestones
 - Initial risk list
 - Resource needs (team roles, rough effort estimate)
+  _Consider roles such as UX Designer, DevOps Engineer, Business Analyst, and Support Lead depending on project complexity._
 
 ## Project One-pager Template
 - Project name:

--- a/docs/octoacme-project-planning.md
+++ b/docs/octoacme-project-planning.md
@@ -24,6 +24,8 @@ Turn an approved initiative into an actionable plan and backlog for delivery.
 - Estimate:
 - Owner:
 - Related docs/links:
+- Support/DevOps/UX Owner (if relevant):
+
 
 ## Sprint / Iteration Planning
 - Timebox planning to agreed sprint length
@@ -41,3 +43,4 @@ Turn an approved initiative into an actionable plan and backlog for delivery.
 - [ ] Release timeline and milestones agreed
 - [ ] Definition of Done documented
 - [ ] Initial test plan / QA approach drafted
+- [ ] Hand-offs and responsibilities for UX, DevOps, Business Analyst, and Support Lead roles clarified (if applicable)

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -79,3 +79,96 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
 
+---
+
+## UX Designer
+
+### Role Summary
+UX Designers advocate for user-centered design, translating requirements into wireframes, prototypes, and usability standards.
+
+### Responsibilities
+- Create wireframes and prototypes for features
+- Conduct usability testing and analyze feedback
+- Collaborate with Product Managers and Developers on feature refinement
+- Document UX guidelines
+
+### Goals
+- Maximize usability and customer satisfaction
+- Reduce friction and confusion in user workflows
+
+### Typical Communication
+- Design review demos with Product/Project Managers, Developers
+- Usability test feedback sessions
+
+### Interactions
+Works closely with Product Managers (requirements) and Developers (implementation); supports QA in validating usability.
+
+---
+
+## DevOps Engineer
+
+### Role Summary
+DevOps Engineers ensure infrastructure, CI/CD pipelines, and deployments are robust and automated.
+
+### Responsibilities
+- Configure and maintain CI/CD pipelines
+- Monitor deployments and infrastructure health
+- Automate operational and security processes
+- Support incident management
+
+### Goals
+- Accelerate reliable releases with minimal manual steps
+- Increase deployment frequency and system resilience
+
+### Typical Communication
+- Release coordination meetings
+- Incident and deployment postmortems
+
+### Interactions
+Partners with Developers for deployment-ready code, PMs for release plans, QA for automating test pipelines.
+
+---
+
+## Business Analyst
+
+### Role Summary
+Business Analysts map business processes, clarify stakeholder requirements, and ensure backlog items serve business value.
+
+### Responsibilities
+- Gather and document requirements from stakeholders
+- Aid backlog refinement and prioritization
+- Validate acceptance criteria against business value
+
+### Goals
+- Reduce rework by clarifying 'what' and 'why'
+- Bridge business/technical understanding
+
+### Typical Communication
+- Stakeholder interviews, backlog refinement sessions
+- Requirements reviews with PMs, PdMs, Developers, and QA
+
+### Interactions
+Liaises between Product/Project Managers, stakeholders, and the delivery team.
+
+---
+
+## Support Lead
+
+### Role Summary
+Support Leads own post-release user feedback, incident management, and support metrics.
+
+### Responsibilities
+- Monitor user issues and post-release incidents
+- Coordinate escalation/resolution of product issues
+- Report trends and inform retrospectives
+
+### Goals
+- Improve user satisfaction and reduce unresolved incidents
+- Drive post-release continuous improvement
+
+### Typical Communication
+- Regular touchpoints with PMs/PdMs about open support tickets
+- Escalation reports, incident summaries
+
+### Interactions
+Works with QA (bug triage), Developers (fixes), PM/PdM (prioritization), and users (feedback).

--- a/docs/role-handoff-checklist.md
+++ b/docs/role-handoff-checklist.md
@@ -1,0 +1,5 @@
+# Role Handoff Checklist
+
+- [ ] All new roles (UX Designer, DevOps, Business Analyst, Support Lead) included in team communications, as applicable
+- [ ] Handoffs and responsibilities documented for each role
+- [ ] Escalation and contact points for post-release support identified


### PR DESCRIPTION
This PR updates OctoAcme project management docs to:

Add UX Designer, DevOps Engineer, Business Analyst, Support Lead to roles/personas documentation
Clarify handoff and support responsibilities in initiation, planning, and execution docs
Add an example role handoff checklist template
Closes #4